### PR TITLE
Potential namespace fix

### DIFF
--- a/src/Fjage.jl
+++ b/src/Fjage.jl
@@ -262,7 +262,7 @@ function _messageclass(clazz::String, performative)
       dict = Dict{String,Any}(
         "msgID" => string(uuid4()),
         "perf" => $(esc(string(
-          performative!=nothing ? performative : match(r"Req$",string(clazz))==nothing ? Performative.INFORM : Performative.REQUEST
+          $(esc(performative))!=nothing ? $(esc(performative)) : match(r"Req$",string(clazz))==nothing ? Performative.INFORM : Performative.REQUEST
         )))
       )
       for k in keys(kwargs)

--- a/src/Fjage.jl
+++ b/src/Fjage.jl
@@ -270,7 +270,7 @@ function _messageclass(clazz::String, performative)
       end
       return $(esc(sname))($(string(clazz)), dict)
     end
-    messageclasses[$(esc(clazz))] = $(esc(sname))
+    Fjage.messageclasses[$(esc(clazz))] = $(esc(sname))
   end
 end
 


### PR DESCRIPTION
Untested!
`messageclasses` appears inside a quoted expression, when this expression is evaluated at the call site, `messageclasses` might be undefined, or refer to a binding in the call-site scope.