### PR TITLE
Implement copy(::Message)

### DIFF
--- a/src/msg.jl
+++ b/src/msg.jl
@@ -1,4 +1,4 @@
-export Performative, Message, GenericMessage, MessageClass, AbstractMessageClass, ParameterReq, ParameterRsp, set!
+export Performative, Message, GenericMessage, MessageClass, AbstractMessageClass, clone, ParameterReq, ParameterRsp, set!
 
 # global variables
 const _messageclasses = Dict{String,DataType}()
@@ -93,10 +93,10 @@ function AbstractMessageClass(context, clazz::String, performative=nothing)
   return rv
 end
 
-function Base.copy(original::Message)
-  copied = _messageclass_lookup(original.__clazz__)(original.__clazz__, copy(original.__data__))
-  copied.msgID = string(uuid4())
-  return copied
+function clone(original::Message)
+  cloned = _messageclass_lookup(original.__clazz__)(original.__clazz__, deepcopy(original.__data__))
+  cloned.msgID = string(uuid4())
+  return cloned
 end
 
 """

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -93,6 +93,12 @@ function AbstractMessageClass(context, clazz::String, performative=nothing)
   return rv
 end
 
+function Base.copy(original::Message)
+  copied = _messageclass_lookup(original.__clazz__)(original.__clazz__, copy(original.__data__))
+  copied.msgID = string(uuid4())
+  return copied
+end
+
 """
     registermessages()
     registermessages(messageclasses)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -319,3 +319,14 @@ end
     @test t1 - t0 > dt
   end
 end
+
+@testset "copy(::Message)" begin
+  original = GenericMessage()
+  original.data = "test"
+  copied = copy(original)
+
+  @test copied.__clazz__ == original.__clazz__
+  @test typeof(copied) == typeof(original)
+  @test copied.msgID != original.msgID
+  @test copied.data == original.data
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -322,11 +322,12 @@ end
 
 @testset "copy(::Message)" begin
   original = GenericMessage()
-  original.data = "test"
-  copied = copy(original)
+  original.data = [1,2,3]
+  cloned = clone(original)
 
-  @test copied.__clazz__ == original.__clazz__
-  @test typeof(copied) == typeof(original)
-  @test copied.msgID != original.msgID
-  @test copied.data == original.data
+  @test cloned.__clazz__ == original.__clazz__
+  @test typeof(cloned) == typeof(original)
+  @test cloned.msgID != original.msgID
+  @test cloned.data == original.data
+  @test cloned.data !== original.data
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -320,7 +320,7 @@ end
   end
 end
 
-@testset "copy(::Message)" begin
+@testset "clone(::Message)" begin
   original = GenericMessage()
   original.data = [1,2,3]
   cloned = clone(original)


### PR DESCRIPTION
Enables the following:

```
julia> a = GenericMessage(data = "test")
Fjage.org_arl_fjage_GenericMessage with 3 entries:
  :perf  => "INFORM"
  :data  => "test"
  :msgID => "3cbc775e-a925-48f7-aa44-333451d37add"

julia> copy(a)
Fjage.org_arl_fjage_GenericMessage with 3 entries:
  :perf  => "INFORM"
  :data  => "test"
  :msgID => "a5745a38-c557-4d3c-aaa8-78d98ad7dc68"
```