### PR TITLE
Allow messages to be constructed directly from Dicts

### DIFF
--- a/src/msg.jl
+++ b/src/msg.jl
@@ -65,6 +65,8 @@ function MessageClass(context, clazz::String, superclass=nothing, performative=n
     """),
     Meta.parse("""
       function $(sname)(d::Dict{String, Any})
+        get!(d, "msgID", string($(@__MODULE__).uuid4()))
+        get!(d, "perf", "$performative")
         return $(tname)("$(clazz)", d)
       end
     """),

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -64,6 +64,11 @@ function MessageClass(context, clazz::String, superclass=nothing, performative=n
       end
     """),
     Meta.parse("""
+      function $(sname)(d::Dict{String, Any})
+        return $(tname)("$(clazz)", d)
+      end
+    """),
+    Meta.parse("""
       function $(sname)(; kwargs...)
         dict = Dict{String,Any}(
           "msgID" => string($(@__MODULE__).uuid4()),


### PR DESCRIPTION
Adds a constructor of the form `Message(d::Dict{String,Any})` to all message types. This makes it easier to construct e.g. a `TxFrameReq` from a `DatagramReq`, because now all you have to do is make a copy of `frame_req.__data__`. 