### PR TITLE
fix(remote): Call _update_watch when adding an agent

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -382,6 +382,9 @@ function add(c::Container, name::String, a::Agent)
   a._container = c
   a._aid = AgentID(name)
   c.agents[name] = a
+  if c isa SlaveContainer
+    _update_watch(c)
+  end
   c.running[] && init(a)
   @async _msgloop(a)
   @debug "Added agent $(name)::$(typeof(a))"

--- a/src/container.jl
+++ b/src/container.jl
@@ -382,9 +382,7 @@ function add(c::Container, name::String, a::Agent)
   a._container = c
   a._aid = AgentID(name)
   c.agents[name] = a
-  if c isa SlaveContainer
-    _update_watch(c)
-  end
+  c isa SlaveContainer && _update_watch(c)
   c.running[] && init(a)
   @async _msgloop(a)
   @debug "Added agent $(name)::$(typeof(a))"


### PR DESCRIPTION
Currently, `_update_watch(c::SlaveContainer)` is called only when subscribing and unsubscribing to a topic. This means that agents loaded *after* the last subscribe won't receive any messages. This PR adds a call from `add(::SlaveContainer, ...)` to  `_update_watch()` to make sure any agent can receive messages.  