### PR TITLE
Start try block immediately after starting fjage

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,12 +8,12 @@ using Base64
 println("Starting fjåge...")
 cp = replace(read(`find lib -name '*.jar'`, String), "\n" => ":")
 master = open(`java -cp $cp org.arl.fjage.shell.GroovyBoot etc/initrc.groovy`)
-sleep(2)
-
-# tests
-
-println("Starting tests...")
 try
+  sleep(2)
+
+  # tests
+
+  println("Starting tests...")
 
   @testset "Fjage" begin
 


### PR DESCRIPTION
Change 

```julia
master = open(`...`)
sleep(2.0)
try
  ...
```

to 

```julia
master = open(`...`)
try
  sleep(2.0)
  ...
```

If not, interrupting the test during `sleep()` will leak the fjage process, and this causes issues the next time you're trying to run the test. 