### PR TITLE
Implement _agentsforservice for all container types

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -687,7 +687,7 @@ _agents_types(c::SlaveContainer) = [(k, string(typeof(v))) for (k, v) ∈ c.agen
 _subscriptions(c::SlaveContainer) = collect(string.(keys(c.topics)))
 _services(c::SlaveContainer) = collect(keys(c.services))
 
-function _agentsforservice(c::SlaveContainer, svc::String)
+function _agentsforservice(c::Container, svc::String)
   svc ∈ keys(c.services) || return AgentID[]
   collect(c.services[svc])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -329,14 +329,16 @@ end
     # Test that delay indeed delays for at least as long as promised
     dt = 100
     t = zeros(Int, 10)
+    cond = Threads.Condition()
     b = CoroutineBehavior() do a, b
       for i in eachindex(t)
         t[i] = currenttimemillis(a)
         delay(b, dt)
       end
+      lock(()->notify(cond), cond)
     end
     add(a, b)
-    sleep(1.0 + length(t) * dt * 1e-3)
+    lock(()->wait(cond), cond)
 
     @test done(b)
     @test all(diff(t) .>= dt)


### PR DESCRIPTION
`_agentsforservice` is called in [`Fjage.init(::UnetAgent)`](https://github.com/org-arl/unet/blob/8b39604d15b28a3d942b8e692506e8e3681afbdf/unet-julia/src/utils/Unet.jl#L100), but it is not implemented for `StandaloneContainers`. I guess there aren't many occasions where you'd want to run a `UnetAgent` on a `StandaloneContainer`, but I'm doing precisely that for some quick and easy testing. I'd therefore like to extend the domain of `_agentsforservice()` to support this use case. 

---

This PR uncovered and now depends on https://github.com/org-arl/Fjage.jl/pull/38. 