### PR TITLE
Add separate reconnect() methods for Standalone and SlaveContainers

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -56,7 +56,8 @@ end
 
 reporterror(ex) = reporterror(nothing, ex)
 
-function reconnect(c, ex)
+reconnect(c::StandaloneContainer, ex) = false
+function reconnect(c::SlaveContainer, ex)
   c.reconnect[] || return false
   isopen(c.sock[]) && return false
   ex isa IOError || return false

--- a/src/container.jl
+++ b/src/container.jl
@@ -37,35 +37,6 @@ function loglevel!(level)
   throw(ArgumentError("Bad loglevel (allowed values are :debug, :info, :warn, :error, :none)"))
 end
 
-### stacktrace pretty printing & auto-reconnection
-
-function reporterror(src, ex)
-  fname = basename(@__FILE__)
-  bt = String[]
-  for s ∈ stacktrace(catch_backtrace())
-    push!(bt, "    $s")
-    basename(string(s.file)) == fname && s.func == :run && break
-  end
-  bts = join(bt, '\n')
-  if src === nothing
-    @error "$(ex)\n  Stack trace:\n$(bts)"
-  else
-    @error "[$(src)] $(ex)\n  Stack trace:\n$(bts)"
-  end
-end
-
-reporterror(ex) = reporterror(nothing, ex)
-
-reconnect(c::StandaloneContainer, ex) = false
-function reconnect(c::SlaveContainer, ex)
-  c.reconnect[] || return false
-  isopen(c.sock[]) && return false
-  ex isa IOError || return false
-  @warn "Connection lost..."
-  close(c.sock[])
-  true
-end
-
 ### realtime platform
 
 "Real-time platform."
@@ -723,6 +694,35 @@ function _deliver(c::SlaveContainer, msg::Message, relay::Bool)
 end
 
 _deliver(c::SlaveContainer, msg::Message) = _deliver(c, msg, true)
+
+### stacktrace pretty printing & auto-reconnection
+
+function reporterror(src, ex)
+  fname = basename(@__FILE__)
+  bt = String[]
+  for s ∈ stacktrace(catch_backtrace())
+    push!(bt, "    $s")
+    basename(string(s.file)) == fname && s.func == :run && break
+  end
+  bts = join(bt, '\n')
+  if src === nothing
+    @error "$(ex)\n  Stack trace:\n$(bts)"
+  else
+    @error "[$(src)] $(ex)\n  Stack trace:\n$(bts)"
+  end
+end
+
+reporterror(ex) = reporterror(nothing, ex)
+
+reconnect(c::StandaloneContainer, ex) = false
+function reconnect(c::SlaveContainer, ex)
+  c.reconnect[] || return false
+  isopen(c.sock[]) && return false
+  ex isa IOError || return false
+  @warn "Connection lost..."
+  close(c.sock[])
+  true
+end
 
 ### agent
 


### PR DESCRIPTION
All behaviors execute user code in a `try ... catch` block as follows.

```julia
try
    ...
catch ex
    reconnect(container(b.agent), ex) || reporterror(b.agent, ex)
end
```

Currently, `reconnect(c, ex)` implicitly assumes that `c` is a `SlaveContainer`, because it references `c.reconnect` which is a field of `SlaveContainer` but not `StandaloneContainer`. 

https://github.com/org-arl/Fjage.jl/blob/9b50e7bae307beb4c695b6dbeda817ff37de1b77/src/container.jl#L59-L66

Consequently, errors in user code running on a `StandaloneContainer` trigger an exception in the `catch` clause. This silently kills the behavior task and thereby makes it difficult to track down such bugs. 

This PR fixes this issue by restricting the old implementation of `reconnect(c, ex)` to `c::SlaveContainer` and adding a separate method for `c::StandaloneContainer`. This in turn forced me to move these method definitions so they appear after the container type definitions. 