### PR TITLE
fix(msg): Check for p.param being nothing in get(p::ParamRsp)

### DIFF
--- a/src/msg.jl
+++ b/src/msg.jl
@@ -369,7 +369,7 @@ Extract parameter `param` from a parameter response message.
 function Base.get(p::ParameterRsp, key)
   skey = string(key)
   dskey = "." * skey
-  (p.param == skey || endswith(p.param, dskey)) && return p.value
+  (!isnothing(p.param) && (p.param == skey || endswith(p.param, dskey))) && return p.value
   vals = p.values
   if vals !== nothing
     for (k, v) ∈ vals


### PR DESCRIPTION
The default `ParameterMessageBehavior` does not set `rsp.param` if all fields in the corresponding request are undefined / `null`. However, the `endswidth` in the following piece of code leads to a method error if `p.param` is `nothing`. 

https://github.com/org-arl/Fjage.jl/blob/b24b95dc48d437b9ea5f096b20b079df30f1a16a/src/msg.jl#L369-L372

This PR introduces an extra check to cover this case. 