### PR TITLE
Allow non-string host (e.g. IPv4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.github.org-arl</groupId>
     <artifactId>Fjage.jl</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.1.0</version>
     <repositories>
         <repository>
         <id>snapshots</id>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.github.org-arl</groupId>
             <artifactId>fjage</artifactId>
-            <version>1.10.0-SNAPSHOT</version>
+            <version>1.12.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/gw.jl
+++ b/src/gw.jl
@@ -11,15 +11,13 @@ struct Gateway
   sock::Ref{TCPSocket}
   subscriptions::Set{String}
   pending::Dict{String,Channel}
-
   msgqueue::Vector
   tasks_waiting_for_msg::Vector{Tuple{Task,#=receive_id::=#Int}}
   msgqueue_lock::ReentrantLock # Protects both msgqueue and tasks_waiting_for_msg
-
   host::String
   port::Int
   reconnect::Ref{Bool}
-  function Gateway(name::String, host::String, port::Int; reconnect=true)
+  function Gateway(name::String, host, port::Int; reconnect=true)
     gw = new(
       AgentID(name, false),
       Ref(connect(host, port)),
@@ -28,14 +26,14 @@ struct Gateway
       Vector(),
       Vector{Tuple{Task,Int}}(),
       ReentrantLock(),
-      host, port, Ref(reconnect)
+      string(host), port, Ref(reconnect)
     )
     @async _run(gw)
     gw
   end
 end
 
-Gateway(host::String, port::Int; reconnect=true) = Gateway("julia-gw-" * string(uuid1()), host, port; reconnect=reconnect)
+Gateway(host, port::Int; reconnect=true) = Gateway("julia-gw-" * string(uuid1()), host, port; reconnect=reconnect)
 
 Base.show(io::IO, gw::Gateway) = print(io, gw.agentID.name)
 


### PR DESCRIPTION
Allows gateway to be created from host entry that is an IP address or anything else connect supports.

P.S. Also fixes broken test suite.