### PR TITLE
Add `name` as agent parameter

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -1912,6 +1912,7 @@ params(a::Agent) = Pair{String,Symbol}[]
 params(a::Agent, ndx) = Pair{String,Symbol}[]
 
 Fjage.get(a::Agent, ::Val{:type}) = string(typeof(a))
+Fjage.get(a::Agent, ::Val{:name}) = string(AgentID(a))
 Fjage.get(a::Agent, ::Val{:title}) = string(AgentID(a))
 Fjage.get(a::Agent, ::Val{:description}) = ""
 
@@ -2077,6 +2078,7 @@ end
 
 function _resolve(plist, p, ndx)
   psym = Symbol(p)
+  psym === :name && return p, psym
   psym === :type && return p, psym
   psym === :title && return p, psym
   psym === :description && return p, psym

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -500,6 +500,7 @@ function Base.println(io::IO, p::ParameterRsp)
   ro = p.readonly === nothing ? String[] : p.readonly
   for (k, v) ∈ plist
     k === ".type" && continue
+    k === ".name" && continue
     k === ".title" && continue
     k === ".description" && continue
     ks = split(k, '.')


### PR DESCRIPTION
In Java, we have `name` as an automatic agent parameter. This currently doesn't work in Julia. This PR fixes that.

Demo after the fix:
```groovy
> bb << new ParameterReq().get(new NamedParameter("name"))
ParameterRsp[name*:bb]
```