### PR TITLE
Extend byte <> UInt8 conversion to union types

### DIFF
--- a/src/msg.jl
+++ b/src/msg.jl
@@ -158,7 +158,7 @@ function trysetproperty!(s::Message, p::Symbol, v)
   hasfield(typeof(s), p) || return s
   ftype = fieldtype(typeof(s), p)
   ftype === Symbol && (v = Symbol(v))
-  ftype === Vector{UInt8} && v isa Vector{Int8} && (v = reinterpret(UInt8, v))
+  Vector{UInt8} <: ftype  && v isa Vector{Int8} && (v = reinterpret(UInt8, v))
   if v === nothing
     ftype === Float32 && (v = NaN32)
     ftype === Float64 && (v = NaN64)


### PR DESCRIPTION
Java uses signed bytes, and in Julia we use `UInt8` for bytes. This requires auto conversion since the JSON representation from Java has signed values that Julia refuses. The conversion worked fine when the target was a `Vector{UInt8}` but failed for `Union{Nothing,Vector{UInt8}}` or similar types. This PR fixes that.