### PR TITLE
Fix bugs related to shell requests

### DIFF
--- a/docs/src/gw.md
+++ b/docs/src/gw.md
@@ -10,11 +10,11 @@ julia> shell = agentforservice(gw, "org.arl.fjage.shell.Services.SHELL")
 shell
 julia> shell.language
 "Groovy"
-julia> request(gw, ShellExecReq(recipient=shell, cmd="ps"))
+julia> request(gw, ShellExecReq(recipient=shell, command="ps"))
 AGREE
-julia> request(shell, ShellExecReq(cmd="ps"))
+julia> request(shell, ShellExecReq(command="ps"))
 AGREE
-julia> shell << ShellExecReq(cmd="ps")
+julia> shell << ShellExecReq(command="ps")
 AGREE
 julia> close(gw)
 ```

--- a/docs/src/msg.md
+++ b/docs/src/msg.md
@@ -7,9 +7,7 @@ message classes with fields with the same name as the keys in the message.
 Message types are defined using the `@message` macro. For example:
 ```julia
 @message "org.arl.fjage.shell.ShellExecReq" struct ShellExecReq
-  cmd::Union{String,Nothing} = nothing
-  script::Union{String,Nothing} = nothing
-  args::Vector{String} = String[]
+  command::Union{String,Nothing} = nothing
   ans::Bool = false
 end
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.github.org-arl</groupId>
             <artifactId>fjage</artifactId>
-            <version>1.12.2</version>
+            <version>1.15.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/const.jl
+++ b/src/const.jl
@@ -7,8 +7,6 @@ end
 
 "Shell command execution request message."
 @message "org.arl.fjage.shell.ShellExecReq" struct ShellExecReq
-  cmd::Union{String,Nothing} = nothing
-  script::Union{String,Nothing} = nothing
-  args::Vector{String} = String[]
+  command::Union{String,Nothing} = nothing
   ans::Bool = false
 end

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -93,10 +93,10 @@ the performative is assumed to be REQUEST, and for all other messages, INFORM.
 
 ```julia-repl
 julia> @message "org.arl.fjage.shell.MyShellExecReq" struct MyShellExecReq
-         cmd::String
+         command::String
        end
-julia> req = MyShellExecReq(cmd="ps")
-MyShellExecReq:REQUEST[cmd:"ps"]
+julia> req = MyShellExecReq(command="ps")
+MyShellExecReq:REQUEST[command:"ps"]
 ```
 """
 macro message(classname, perf, sdef)

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -320,8 +320,18 @@ Base.length(s::GenericMessage) = fieldcount(typeof(s)) - 1 + length(s.__data__)
 
 function Base.iterate(s::GenericMessage)
   f = keys(s)
+  fiter = iterate(f)
+  fiter === nothing && return nothing
   v = values(s)
-  (f[1] => v[1], (f[2:end], v[2:end]))
+  (fiter[1] => first(v), (fiter[2], 2))
+end
+
+function Base.iterate(s::GenericMessage, (fstate, vndx))
+  f = keys(s)
+  fiter = iterate(f, fstate)
+  fiter === nothing && return nothing
+  v = values(s)
+  (fiter[1] => v[vndx], (fiter[2], vndx+1))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,7 +71,7 @@ try
       channel = Channel()
       @async put!(channel, receive(gw, 1000))
       yield()
-      send(gw, ShellExecReq(recipient=shell, cmd="1+2"))
+      send(gw, ShellExecReq(recipient=shell, command="1+2"))
       rsp = take!(channel)
       @test typeof(rsp) <: Message
       @test rsp.performative == Performative.AGREE
@@ -82,7 +82,7 @@ try
 
     @testset "send & receive (gw, nonblocking)" begin
       flush(gw)
-      send(gw, ShellExecReq(recipient=shell, cmd="1+2"))
+      send(gw, ShellExecReq(recipient=shell, command="1+2"))
       rsp = nothing
       for _ = 1:10
         rsp = receive(gw)
@@ -100,7 +100,7 @@ try
 
     @testset "send & receive (aid)" begin
       flush(gw)
-      send(shell, ShellExecReq(cmd="1+2"))
+      send(shell, ShellExecReq(command="1+2"))
       rsp = receive(gw, 1000)
       @test typeof(rsp) <: Message
       @test rsp.performative == Performative.AGREE
@@ -108,21 +108,21 @@ try
 
     @testset "request (gw)" begin
       flush(gw)
-      rsp = request(gw, ShellExecReq(recipient=shell, cmd="1+2"))
+      rsp = request(gw, ShellExecReq(recipient=shell, command="1+2"))
       @test typeof(rsp) <: Message
       @test rsp.performative == Performative.AGREE
     end
 
     @testset "request (aid)" begin
       flush(gw)
-      rsp = request(shell, ShellExecReq(cmd="1+2"))
+      rsp = request(shell, ShellExecReq(command="1+2"))
       @test typeof(rsp) <: Message
       @test rsp.performative == Performative.AGREE
     end
 
     @testset "<< (aid, +)" begin
       flush(gw)
-      rsp = shell << ShellExecReq(cmd="1+2")
+      rsp = shell << ShellExecReq(command="1+2")
       @test typeof(rsp) <: Message
       @test rsp.performative == Performative.AGREE
     end
@@ -134,13 +134,13 @@ try
     end
 
     @testset "<< (aid, -)" begin
-      rsp = dummy << ShellExecReq(cmd="1+2")
+      rsp = dummy << ShellExecReq(command="1+2")
       @test rsp == nothing
     end
 
     @testset "flush" begin
       flush(gw)
-      send(gw, ShellExecReq(recipient=shell, cmd="1+2"))
+      send(gw, ShellExecReq(recipient=shell, command="1+2"))
       sleep(1)
       flush(gw)
       rsp = receive(gw, 1000)
@@ -155,7 +155,7 @@ try
 
     @testset "subscribe (-)" begin
       flush(gw)
-      send(ntf, ShellExecReq(cmd="1+2"))
+      send(ntf, ShellExecReq(command="1+2"))
       msg = receive(gw, 1000)
       @test msg == nothing
     end
@@ -163,7 +163,7 @@ try
     @testset "subscribe (+)" begin
       flush(gw)
       subscribe(gw, ntf)
-      send(ntf, ShellExecReq(cmd="1+2+3"))
+      send(ntf, ShellExecReq(command="1+2+3"))
       msg = receive(gw, 1000)
       @test typeof(msg) <: ShellExecReq
     end
@@ -173,7 +173,7 @@ try
       channel = Channel()
       @async put!(channel, receive(gw, ShellExecReq, 1000))
       yield()
-      send(ntf, ShellExecReq(cmd="1+2"))
+      send(ntf, ShellExecReq(command="1+2"))
       msg = take!(channel)
       @test typeof(msg) <: ShellExecReq
       # make sure response is removed
@@ -183,7 +183,7 @@ try
 
     @testset "receive (filt, +, nonblocking)" begin
       flush(gw)
-      send(ntf, ShellExecReq(cmd="1+2"))
+      send(ntf, ShellExecReq(command="1+2"))
       msg = nothing
       for _ = 1:10
         msg = receive(gw, ShellExecReq)
@@ -203,7 +203,7 @@ try
 
     @testset "receive (filt, -)" begin
       flush(gw)
-      send(ntf, ShellExecReq(cmd="1+2"))
+      send(ntf, ShellExecReq(command="1+2"))
       msg = receive(gw, UnknownReq, 1000)
       @test msg == nothing
     end
@@ -211,7 +211,7 @@ try
     @testset "unsubscribe" begin
       unsubscribe(gw, ntf)
       flush(gw)
-      send(ntf, ShellExecReq(cmd="1+2"))
+      send(ntf, ShellExecReq(command="1+2"))
       msg = receive(gw, 1000)
       @test msg == nothing
     end
@@ -236,7 +236,7 @@ try
           f = x as double[]
         }
       }"
-    shell << ShellExecReq(cmd=code)
+    shell << ShellExecReq(command=code)
     sleep(2)
     a = agent(gw, "a")
 
@@ -266,11 +266,11 @@ try
     @testset "reconnect" begin
       flush(gw)
       close(gw.sock[])
-      send(gw, ShellExecReq(recipient=shell, cmd="1+2"))
+      send(gw, ShellExecReq(recipient=shell, command="1+2"))
       rsp = receive(gw, 1000)
       @test rsp === nothing
       for i ∈ 1:10
-        send(gw, ShellExecReq(recipient=shell, cmd="1+2"))
+        send(gw, ShellExecReq(recipient=shell, command="1+2"))
         rsp = receive(gw, 1000)
         rsp === nothing || break
         sleep(1.0)


### PR DESCRIPTION
### Overview

This PR fixes 2 problems:
1. `ShellExecReq` property name should be `command` and not `cmd`. The latter worked because of the way GSON worked in Java, but now we have fixed the naming in Java and so the corresponding Julia message needed update.
2. The iterator on a `GenericMessage` had a bug, causing printing of `GenericMessages` to throw exceptions. We now have a better iterator.

### What was broken

```julia
using Fjage

gw = Gateway("localhost", 1100)   # with fjage master running on localhost:1100
sh = agent(gw, "shell")
```

This was failing with a `REFUSE`:
```
sh << ShellExecReq(cmd="ps")
```
and this was not allowed:
```julia
sh << ShellExecReq(command="ps")
```

With `cmd` replaced by `command` in the message definition, this worked:
```julia
sh << ShellExecReq(command="ps")
```
but this was failing with an exception:
```julia
sh << ShellExecReq(command="ps", ans=true)
```

All of this works after this PR!
