### PR TITLE
Improve handling of complex arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Fjage"
 uuid = "e0fd600c-be67-11e9-1f90-d366689e4029"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.5.2"
+version = "0.6.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
Improves complex and multidimensional array handling. When an array is complex, the equivalent `__isComplex` field defined in the fjåge gateway specification is automatically added and set to `true`.

If the array is multidimensional, it is serialized in Fortran order (in line with Python gateway implementation). There is no official recommendation from fjåge for multidimensional arrays at this time, but having consistency across implementations is desirable.