### PR TITLE
Fix races in behavior block/restart protocol and agent message delivery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: test
 
 test:
 	[ -d test/lib ] || (mkdir -p test/lib test/logs; mvn dependency:copy-dependencies -DoutputDirectory=test/lib)
-	julia test/test.jl
+	JULIA_NUM_THREADS=4 julia test/test.jl
 
 clean:
 	rm -rf test/lib test/logs

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Fjage = "e0fd600c-be67-11e9-1f90-d366689e4029"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 PkgVersion = "eebad327-c553-4316-9ea0-9fa01ccd7688"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1"

--- a/src/Fjage.jl
+++ b/src/Fjage.jl
@@ -2,7 +2,8 @@
 Julia-fjåge gateway, standalone container, and slave container.
 
 Notes:
-- This implementation is not thread-safe.
+- The `Gateway` is not thread-safe, and should only be used from a single task/thread.
+- Containers and agents are designed to be safe to use from multiple threads.
 """
 module Fjage
 

--- a/src/container.jl
+++ b/src/container.jl
@@ -1382,14 +1382,16 @@ end
 Restart a blocked behavior, previous blocked by `block(b)`.
 """
 function restart(b::Behavior)
-  b.block === nothing && return
+  oblock = b.block
+  oblock === nothing && return
   if b.timer !== nothing
     close(b.timer)
     return nothing
   end
-  oblock = b.block
-  b.block = nothing
-  lock(() -> notify(oblock), oblock)
+  lock(oblock) do
+    b.block = nothing
+    notify(oblock)
+  end
   nothing
 end
 
@@ -1476,7 +1478,8 @@ OneShotBehavior(action) = OneShotBehavior(nothing, nothing, nothing, false, 0, n
 function action(b::OneShotBehavior)
   try
     b.onstart === nothing || _mutex_call(b.onstart, b.agent, b)
-    b.block === nothing || lock(() -> wait(b.block), b.block)
+    oblock = b.block
+    oblock === nothing || lock(() -> b.block === nothing || wait(oblock), oblock)
     b.action === nothing || _mutex_call(b.action, b.agent, b)
     b.onend === nothing || _mutex_call(b.onend, b.agent, b)
   catch ex
@@ -1529,7 +1532,8 @@ function action(b::CyclicBehavior)
   try
     b.onstart === nothing || _mutex_call(b.onstart, b.agent, b)
     while !b.done
-      if b.block === nothing
+      oblock = b.block
+      if oblock === nothing
         try
           b.action === nothing || _mutex_call(b.action, b.agent, b)
         catch ex
@@ -1537,7 +1541,7 @@ function action(b::CyclicBehavior)
         end
         yield()
       else
-        lock(() -> wait(b.block), b.block)
+        lock(() -> b.block === nothing || wait(oblock), oblock)
       end
     end
     b.onend === nothing || _mutex_call(b.onend, b.agent, b)
@@ -1623,7 +1627,8 @@ function action(b::WakerBehavior)
     b.onstart === nothing || _mutex_call(b.onstart, b.agent, b)
     while !b.done
       block(b, b.millis)
-      b.block === nothing || lock(() -> wait(b.block), b.block)
+      oblock = b.block
+      oblock === nothing || lock(() -> b.block === nothing || wait(oblock), oblock)
       if !b.done
         b.done = true
         b.action === nothing || _mutex_call(b.action, b.agent, b)
@@ -1698,7 +1703,8 @@ function action(b::TickerBehavior)
     b.onstart === nothing || _mutex_call(b.onstart, b.agent, b)
     while !b.done
       block(b, b.millis)
-      b.block === nothing || lock(() -> wait(b.block), b.block)
+      oblock = b.block
+      oblock === nothing || lock(() -> b.block === nothing || wait(oblock), oblock)
       b.ticks += 1
       try
         b.done || b.action === nothing || _mutex_call(b.action, b.agent, b)
@@ -1765,7 +1771,8 @@ function action(b::PoissonBehavior)
     b.onstart === nothing || _mutex_call(b.onstart, b.agent, b)
     while !b.done
       block(b, round(Int64, b.millis * randexp()))
-      b.block === nothing || lock(() -> wait(b.block), b.block)
+      oblock = b.block
+      oblock === nothing || lock(() -> b.block === nothing || wait(oblock), oblock)
       b.ticks += 1
       try
         b.done || b.action === nothing || _mutex_call(b.action, b.agent, b)

--- a/src/container.jl
+++ b/src/container.jl
@@ -1178,13 +1178,16 @@ function receive(a::Agent, filt, timeout::Int=0; priority=(filt===nothing ? 0 : 
   if timeout > 0
     @async begin
       delay(a, timeout)
-      put!(ch, nothing)
+      try
+        put!(ch, nothing)
+      catch
+        # channel already closed; ignore
+      end
     end
   end
   lock(() -> notify(a._processmsg, true), a._processmsg)
   msg = take!(ch)
-  _dont_listen(a, ch)
-  close(ch)
+  _stop_listening(a, ch)
   msg
 end
 
@@ -1207,12 +1210,15 @@ function request(a::Agent, msg::Message, timeout::Int=timeout[])
   if timeout > 0
     @async begin
       delay(a, timeout)
-      put!(ch, nothing)
+      try
+        put!(ch, nothing)
+      catch
+        # channel already closed; ignore
+      end
     end
   end
   msg = take!(ch)
-  _dont_listen(a, ch)
-  close(ch)
+  _stop_listening(a, ch)
   msg
 end
 
@@ -1246,10 +1252,30 @@ function _dont_listen(a::Agent, ch::Channel)
   end
 end
 
+# stop listening on a channel, and re-deliver any messages left behind in it
+#
+# The channel is closed before deregistering, so that a sender blocked on a
+# `put!` into a full channel is woken (with an exception) rather than deadlocking
+# against `_dont_listen` on the `_processmsg` lock (see issue #36). All `put!`s
+# into listener channels hold the `_processmsg` lock, so once `_dont_listen`
+# returns, no new message can arrive and the channel can be safely drained.
+function _stop_listening(a::Agent, ch::Channel)
+  close(ch)
+  _dont_listen(a, ch)
+  while isready(ch)
+    m = take!(ch)
+    m isa Message && _deliver(a, m)
+  end
+end
+
 function _listener_notify(a::Agent)
   lock(a._processmsg) do
     for (filt, ch, p) ∈ a._listeners
-      put!(ch, nothing)
+      try
+        isready(ch) || put!(ch, nothing)
+      catch
+        # channel closed by a listener that is deregistering; ignore
+      end
     end
   end
 end
@@ -1278,15 +1304,23 @@ end
 function _msgloop(a::Agent)
   @debug "Start $(a) message loop"
   lock(a._processmsg) do
-    while wait(a._processmsg)
+    keepgoing = true
+    while keepgoing
+      # deliver before waiting, since messages may have arrived (and notifications
+      # been lost) before this loop started or between sweeps
       try
         @debug "Deliver messages in $(a) [qlen=$(length(a._msgqueue))]"
         filter!(a._msgqueue) do msg
           for (filt, ch, p) ∈ a._listeners
             if _matches(filt, msg)
               isready(ch) && return true
-              put!(ch, msg)
-              return false
+              try
+                put!(ch, msg)
+                return false
+              catch
+                # channel closed by a listener that is deregistering; keep message
+                return true
+              end
             end
           end
           true
@@ -1294,6 +1328,7 @@ function _msgloop(a::Agent)
       catch ex
         @warn "Message delivery failed: $(ex)"
       end
+      keepgoing = wait(a._processmsg)
     end
   end
   @debug "Stop $(a) message loop"
@@ -1869,7 +1904,7 @@ end
 ```
 """
 MessageBehavior(action) = MessageBehavior(nothing, nothing, nothing, nothing, false, 0, nothing, action, nothing)
-MessageBehavior(action, filt) = MessageBehavior(nothing, filt, nothing, false, (filt===nothing ? 0 : -100), nothing, action, nothing)
+MessageBehavior(action, filt) = MessageBehavior(nothing, filt, nothing, nothing, false, (filt===nothing ? 0 : -100), nothing, action, nothing)
 
 function action(b::MessageBehavior)
   ch = Channel{Union{Message,Nothing}}(1)
@@ -1889,8 +1924,7 @@ function action(b::MessageBehavior)
   catch ex
     reconnect(container(b.agent), ex) || logerror(b.agent)
   finally
-    _dont_listen(b.agent, ch)
-    close(ch)
+    _stop_listening(b.agent, ch)
   end
   b.done = true
   delete!(b.agent._behaviors, b)

--- a/src/container.jl
+++ b/src/container.jl
@@ -1357,24 +1357,33 @@ restarted after `millis` milliseconds.
 """
 function block(b::Behavior)
   done(b) && return
+  b.block === nothing || return
   b.block = Threads.Condition()
   nothing
 end
 
 function block(b::Behavior, millis)
   done(b) && return
+  b.block === nothing || return
   b.block = Threads.Condition()
-  b.timer = Timer(millis/1000)
+  t = Timer(millis/1000)
+  b.timer = t
   @async begin
     try
-      wait(b.timer)
+      wait(t)
     finally
-      b.timer = nothing
-      restart(b)
+      if b.timer === t
+        b.timer = nothing
+        restart(b)
+      end
     end
   end
   nothing
 end
+
+# b.block and b.timer are plain fields that may be written from multiple threads;
+# the identity checks against a locally captured copy, performed while holding the
+# condition's lock, are what make the block/restart/reset protocol safe.
 
 """
     restart(b::Behavior)
@@ -1382,15 +1391,34 @@ end
 Restart a blocked behavior, previous blocked by `block(b)`.
 """
 function restart(b::Behavior)
-  oblock = b.block
-  oblock === nothing && return
-  if b.timer !== nothing
-    close(b.timer)
+  b.block === nothing && return
+  t = b.timer
+  if t !== nothing
+    close(t)
     return nothing
   end
+  _release_block(b)
+end
+
+# release anyone waiting on a behavior's block condition
+function _release_block(b::Behavior)
+  oblock = b.block
+  oblock === nothing && return
   lock(oblock) do
-    b.block = nothing
+    b.block === oblock && (b.block = nothing)
     notify(oblock)
+  end
+  nothing
+end
+
+# wait until a behavior is no longer blocked (or is done)
+function _wait_for_restart(b::Behavior)
+  while !done(b)
+    oblock = b.block
+    oblock === nothing && return
+    lock(oblock) do
+      b.block === oblock && wait(oblock)
+    end
   end
   nothing
 end
@@ -1403,9 +1431,10 @@ reset, it may be reused later by adding it to an agent.
 """
 function reset(b::Behavior)
   b.agent === nothing || delete!(b.agent._behaviors, b)
-  b.timer === nothing || close(b.timer)
+  t = b.timer
+  t === nothing || close(t)
+  _release_block(b)
   b.agent = nothing
-  b.block = nothing
   b.timer = nothing
   b.done = false
   nothing
@@ -1478,8 +1507,7 @@ OneShotBehavior(action) = OneShotBehavior(nothing, nothing, nothing, false, 0, n
 function action(b::OneShotBehavior)
   try
     b.onstart === nothing || _mutex_call(b.onstart, b.agent, b)
-    oblock = b.block
-    oblock === nothing || lock(() -> b.block === nothing || wait(oblock), oblock)
+    _wait_for_restart(b)
     b.action === nothing || _mutex_call(b.action, b.agent, b)
     b.onend === nothing || _mutex_call(b.onend, b.agent, b)
   catch ex
@@ -1532,8 +1560,7 @@ function action(b::CyclicBehavior)
   try
     b.onstart === nothing || _mutex_call(b.onstart, b.agent, b)
     while !b.done
-      oblock = b.block
-      if oblock === nothing
+      if b.block === nothing
         try
           b.action === nothing || _mutex_call(b.action, b.agent, b)
         catch ex
@@ -1541,7 +1568,7 @@ function action(b::CyclicBehavior)
         end
         yield()
       else
-        lock(() -> b.block === nothing || wait(oblock), oblock)
+        _wait_for_restart(b)
       end
     end
     b.onend === nothing || _mutex_call(b.onend, b.agent, b)
@@ -1627,8 +1654,7 @@ function action(b::WakerBehavior)
     b.onstart === nothing || _mutex_call(b.onstart, b.agent, b)
     while !b.done
       block(b, b.millis)
-      oblock = b.block
-      oblock === nothing || lock(() -> b.block === nothing || wait(oblock), oblock)
+      _wait_for_restart(b)
       if !b.done
         b.done = true
         b.action === nothing || _mutex_call(b.action, b.agent, b)
@@ -1703,8 +1729,7 @@ function action(b::TickerBehavior)
     b.onstart === nothing || _mutex_call(b.onstart, b.agent, b)
     while !b.done
       block(b, b.millis)
-      oblock = b.block
-      oblock === nothing || lock(() -> b.block === nothing || wait(oblock), oblock)
+      _wait_for_restart(b)
       b.ticks += 1
       try
         b.done || b.action === nothing || _mutex_call(b.action, b.agent, b)
@@ -1771,8 +1796,7 @@ function action(b::PoissonBehavior)
     b.onstart === nothing || _mutex_call(b.onstart, b.agent, b)
     while !b.done
       block(b, round(Int64, b.millis * randexp()))
-      oblock = b.block
-      oblock === nothing || lock(() -> b.block === nothing || wait(oblock), oblock)
+      _wait_for_restart(b)
       b.ticks += 1
       try
         b.done || b.action === nothing || _mutex_call(b.action, b.agent, b)

--- a/src/coroutine_behavior.jl
+++ b/src/coroutine_behavior.jl
@@ -60,9 +60,7 @@ function action(b::CoroutineBehavior)
     end
     logerror(b.agent) do
         while !b.done
-            if !isnothing(b.block)
-                lock(() -> wait(b.block), b.block)
-            end
+            _wait_for_restart(b)
             _mutex_call(b.agent) do agent
                 yieldto(b.action_task)
             end

--- a/src/fsm.jl
+++ b/src/fsm.jl
@@ -106,9 +106,10 @@ function reset(b::FSMBehavior)
   end
   empty!(b.wakers)
   b.agent === nothing || delete!(b.agent._behaviors, b)
-  b.timer === nothing || close(b.timer)
+  t = b.timer
+  t === nothing || close(t)
+  _release_block(b)
   b.agent = nothing
-  b.block = nothing
   b.timer = nothing
   b.state = INIT
   b.prevstate = INIT
@@ -218,7 +219,7 @@ function action(b::FSMBehavior)
         end
         yield()
       else
-        lock(() -> wait(b.block), b.block)
+        _wait_for_restart(b)
       end
     end
   catch ex

--- a/test/container_tests.jl
+++ b/test/container_tests.jl
@@ -1,0 +1,386 @@
+# tests for standalone containers, agents and behaviors (no Java master needed)
+
+using Test
+using Fjage
+
+# wait for a predicate to become true, with a generous timeout for slow CI machines
+waitfor(pred; timeout=10.0) = timedwait(() -> pred() === true, timeout; pollint=0.01) === :ok
+
+@message "org.arl.fjage.test.CTMsg" struct CTMsg
+  x::Int = 0
+end
+
+@message "org.arl.fjage.test.CTReq" Performative.REQUEST struct CTReq end
+
+@agent struct CTAgent end
+
+# agent that replies AGREE to any CTReq it receives
+@agent struct CTEchoAgent end
+
+function Fjage.processrequest(a::CTEchoAgent, req::CTReq)
+  rsp = CTMsg(x=42)
+  rsp.recipient = req.sender
+  rsp.inReplyTo = req.messageID
+  rsp.performative = Performative.AGREE
+  rsp
+end
+
+# agent that counts every CTMsg reaching its default message handler
+@agent struct CTSinkAgent
+  count::Threads.Atomic{Int} = Threads.Atomic{Int}(0)
+end
+
+function Fjage.processmessage(a::CTSinkAgent, msg)
+  msg isa CTMsg && Threads.atomic_add!(a.count, 1)
+  nothing
+end
+
+@states CT_S1 CT_S2
+
+@fsm struct CTFSM
+  initialstate = CT_S1
+  log::Vector{Symbol} = Symbol[]
+end
+
+function Fjage.onenter(a::Agent, b::CTFSM, ::typeof(CT_S1))
+  push!(b.log, :S1)
+  after(b, 0.05) do
+    nextstate!(b, CT_S2)
+  end
+end
+
+function Fjage.onenter(a::Agent, b::CTFSM, ::typeof(CT_S2))
+  push!(b.log, :S2)
+  after(b, 0.05) do
+    stop(b)
+  end
+end
+
+function ctsend(from::Agent, to, x)
+  msg = CTMsg(x=x)
+  msg.recipient = to isa AgentID ? to : AgentID(to)
+  send(from, msg)
+end
+
+@testset "StandaloneContainer" begin
+  c = Container()
+  start(c)
+  @test isrunning(c)
+  a = CTAgent()
+  add(c, "cta", a)
+  @test containsagent(c, AgentID("cta"))
+  @test canlocateagent(c, AgentID("cta"))
+  @test AgentID(a) == AgentID("cta")
+  register(a, "org.arl.fjage.test.Services.CT")
+  @test agentforservice(a, "org.arl.fjage.test.Services.CT") == AgentID("cta")
+  @test AgentID("cta") ∈ agentsforservice(a, "org.arl.fjage.test.Services.CT")
+  @test agentforservice(a, "org.arl.fjage.test.Services.DUMMY") === nothing
+  kill(c, "cta")
+  @test !containsagent(c, AgentID("cta"))
+  shutdown(c)
+  @test !isrunning(c)
+end
+
+@testset "OneShotBehavior" begin
+  c = Container()
+  start(c)
+  a = CTAgent()
+  add(c, a)
+  trace = Symbol[]
+  b = OneShotBehavior((a, b) -> push!(trace, :action))
+  b.onstart = (a, b) -> push!(trace, :onstart)
+  b.onend = (a, b) -> push!(trace, :onend)
+  add(a, b)
+  @test waitfor(() -> done(b))
+  @test trace == [:onstart, :action, :onend]
+  @test !(b in a._behaviors)
+  shutdown(c)
+end
+
+@testset "CyclicBehavior block/restart/stop" begin
+  c = Container()
+  start(c)
+  a = CTAgent()
+  add(c, a)
+  n = Threads.Atomic{Int}(0)
+  b = CyclicBehavior((a, b) -> Threads.atomic_add!(n, 1))
+  add(a, b)
+  @test waitfor(() -> n[] > 10)
+  # block pauses the behavior
+  block(b)
+  @test isblocked(b)
+  sleep(0.2)
+  n1 = n[]
+  sleep(0.2)
+  @test n[] == n1
+  # block is idempotent: a second block must not replace the condition
+  cond = b.block
+  block(b)
+  @test b.block === cond
+  # restart resumes the behavior
+  restart(b)
+  @test waitfor(() -> n[] > n1)
+  # restart on an unblocked behavior is a no-op
+  restart(b)
+  @test !isblocked(b)
+  # timed block auto-restarts
+  block(b, 100)
+  @test isblocked(b)
+  @test waitfor(() -> !isblocked(b))
+  n2 = n[]
+  @test waitfor(() -> n[] > n2)
+  # stop terminates the behavior, even while blocked
+  block(b)
+  stop(b)
+  @test waitfor(() -> done(b) && !(b in a._behaviors))
+  shutdown(c)
+end
+
+@testset "WakerBehavior" begin
+  c = Container()
+  start(c)
+  a = CTAgent()
+  add(c, a)
+  fired = Ref(-1)
+  t0 = currenttimemillis(a)
+  b = WakerBehavior((a, b) -> (fired[] = currenttimemillis(a) - t0), 500)
+  add(a, b)
+  sleep(0.1)
+  @test fired[] == -1
+  @test waitfor(() -> done(b))
+  @test fired[] >= 400
+  # stopping a waker mid-block must terminate it promptly and without error
+  b2 = WakerBehavior((a, b) -> nothing, 60000)
+  add(a, b2)
+  @test waitfor(() -> isblocked(b2))
+  stop(b2)
+  @test waitfor(() -> done(b2) && !(b2 in a._behaviors))
+  shutdown(c)
+end
+
+@testset "TickerBehavior" begin
+  c = Container()
+  start(c)
+  a = CTAgent()
+  add(c, a)
+  b = TickerBehavior((a, b) -> nothing, 50)
+  add(a, b)
+  @test waitfor(() -> tickcount(b) ≥ 5)
+  stop(b)
+  @test waitfor(() -> done(b) && !(b in a._behaviors))
+  shutdown(c)
+end
+
+@testset "PoissonBehavior" begin
+  c = Container()
+  start(c)
+  a = CTAgent()
+  add(c, a)
+  b = PoissonBehavior((a, b) -> nothing, 20)
+  add(a, b)
+  @test waitfor(() -> tickcount(b) ≥ 3)
+  stop(b)
+  @test waitfor(() -> done(b) && !(b in a._behaviors))
+  shutdown(c)
+end
+
+@testset "block/restart stress" begin
+  c = Container()
+  start(c)
+  a = CTAgent()
+  add(c, a)
+  n = Threads.Atomic{Int}(0)
+  b = CyclicBehavior((a, b) -> Threads.atomic_add!(n, 1))
+  add(a, b)
+  # hammer block/restart (untimed and timed) from concurrent tasks; the behavior
+  # must survive without hanging or crashing, and still run afterwards
+  hammers = [Threads.@spawn begin
+      for _ in 1:250
+        block(b)
+        yield()
+        restart(b)
+        block(b, 1)
+        yield()
+        restart(b)
+      end
+    end for _ in 1:4]
+  @test waitfor(() -> all(istaskdone, hammers); timeout=60.0)
+  @test all(t -> !istaskfailed(t), hammers)
+  restart(b)
+  n1 = n[]
+  @test waitfor(() -> n[] > n1)
+  stop(b)
+  @test waitfor(() -> done(b))
+  shutdown(c)
+end
+
+@testset "FSMBehavior" begin
+  c = Container()
+  start(c)
+  a = CTAgent()
+  add(c, a)
+  b = CTFSM()
+  add(a, b)
+  @test waitfor(() -> done(b))
+  @test b.log == [:S1, :S2]
+  @test state(b) == Fjage.FINAL
+  # reset makes the FSM reusable
+  reset(b)
+  @test state(b) == Fjage.INIT
+  empty!(b.log)
+  add(a, b)
+  @test waitfor(() -> done(b))
+  @test b.log == [:S1, :S2]
+  shutdown(c)
+end
+
+@testset "agent messaging" begin
+  c = Container()
+  start(c)
+  a1 = CTAgent()
+  a2 = CTAgent()
+  add(c, "cta1", a1)
+  add(c, "cta2", a2)
+  # send & receive (blocking, with filter); a receive with a non-matching filter
+  # must time out while a matching receive gets the message
+  rcv1 = Threads.@spawn receive(a2, CTReq, 1000)
+  rcv2 = Threads.@spawn receive(a2, CTMsg, 5000)
+  sleep(0.2)
+  ctsend(a1, "cta2", 7)
+  rsp = fetch(rcv2)
+  @test rsp isa CTMsg
+  @test rsp.x == 7
+  @test rsp.sender == AgentID("cta1")
+  @test fetch(rcv1) === nothing
+  # topics
+  t = topic("ct-news")
+  subscribe(a2, t)
+  rcv = Threads.@spawn receive(a2, CTMsg, 5000)
+  sleep(0.2)
+  ctsend(a1, t, 9)
+  rsp = fetch(rcv)
+  @test rsp isa CTMsg
+  @test rsp.x == 9
+  unsubscribe(a2, t)
+  rcv = Threads.@spawn receive(a2, CTMsg, 500)
+  sleep(0.2)
+  ctsend(a1, t, 10)
+  @test fetch(rcv) === nothing
+  shutdown(c)
+end
+
+@testset "request & reply" begin
+  c = Container()
+  start(c)
+  a1 = CTAgent()
+  echo = CTEchoAgent()
+  add(c, "cta1", a1)
+  add(c, "ctecho", echo)
+  req = CTReq()
+  req.recipient = AgentID("ctecho")
+  rsp = request(a1, req, 5000)
+  @test rsp isa CTMsg
+  @test rsp.performative == Performative.AGREE
+  @test rsp.x == 42
+  # unhandled requests are answered with NOT_UNDERSTOOD by the default handler
+  req = CTReq()
+  req.recipient = AgentID("cta1")
+  rsp = request(echo, req, 5000)
+  @test rsp !== nothing
+  @test rsp.performative == Performative.NOT_UNDERSTOOD
+  shutdown(c)
+end
+
+@testset "message flood (issue #36)" begin
+  c = Container()
+  start(c)
+  a1 = CTAgent()
+  sink = CTSinkAgent()
+  add(c, "cta1", a1)
+  add(c, "ctsink", sink)
+  # concurrently flood the sink with messages while a competing high-priority
+  # receive() loop registers and deregisters a listener; every message must be
+  # consumed exactly once — by receive() or by the default handler — with none
+  # lost or deadlocked (issue #36: put! into an abandoned listener channel)
+  N = 100
+  recvd = Threads.Atomic{Int}(0)
+  stopflag = Ref(false)
+  receiver = Threads.@spawn begin
+    while !stopflag[] && recvd[] + sink.count[] < N
+      m = receive(sink, CTMsg, 100)
+      m === nothing || Threads.atomic_add!(recvd, 1)
+    end
+  end
+  sender = Threads.@spawn begin
+    for i in 1:N
+      ctsend(a1, "ctsink", i)
+      i % 5 == 0 && sleep(0.001)
+    end
+  end
+  ok = waitfor(() -> recvd[] + sink.count[] == N; timeout=60.0)
+  stopflag[] = true
+  @test ok
+  @test waitfor(() -> istaskdone(sender) && istaskdone(receiver); timeout=30.0)
+  @test recvd[] + sink.count[] == N
+  shutdown(c)
+end
+
+@testset "MessageBehavior stop mid-stream (issue #36)" begin
+  c = Container()
+  start(c)
+  a1 = CTAgent()
+  a2 = CTAgent()
+  add(c, "cta1", a1)
+  add(c, "cta2", a2)
+  seen = Threads.Atomic{Int}(0)
+  b = MessageBehavior() do a, b, msg
+    Threads.atomic_add!(seen, 1)
+    sleep(0.02)   # keep the listener channel busy
+  end
+  add(a2, b)
+  sleep(0.1)
+  flood = Threads.@spawn begin
+    for i in 1:100
+      ctsend(a1, "cta2", i)
+      sleep(0.005)
+    end
+  end
+  @test waitfor(() -> seen[] ≥ 5)
+  # stopping the behavior while its channel is full used to deadlock the agent's
+  # message delivery (put! into a full channel under the _processmsg lock)
+  stop(b)
+  @test waitfor(() -> !(b in a2._behaviors); timeout=30.0)
+  # the agent must remain responsive after the behavior is gone
+  req = CTReq()
+  req.recipient = AgentID("cta2")
+  rsp = request(a1, req, 5000)
+  @test rsp !== nothing
+  @test rsp.performative == Performative.NOT_UNDERSTOOD
+  wait(flood)
+  shutdown(c)
+end
+
+@testset "filtered MessageBehavior" begin
+  c = Container()
+  start(c)
+  a1 = CTAgent()
+  a2 = CTAgent()
+  add(c, "cta1", a1)
+  add(c, "cta2", a2)
+  reqs = Threads.Atomic{Int}(0)
+  b = MessageBehavior(CTReq) do a, b, msg
+    Threads.atomic_add!(reqs, 1)
+  end
+  add(a2, b)
+  sleep(0.1)
+  ctsend(a1, "cta2", 1)      # does not match the filter
+  req = CTReq()
+  req.recipient = AgentID("cta2")
+  send(a1, req)
+  @test waitfor(() -> reqs[] == 1)
+  sleep(0.2)
+  @test reqs[] == 1
+  stop(b)
+  @test waitfor(() -> !(b in a2._behaviors))
+  shutdown(c)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,6 +318,8 @@ finally
   kill(master)
 end
 
+include("container_tests.jl")
+
 @testset "CoroutineBehavior" begin
 
   c = Container()


### PR DESCRIPTION
This PR started as a fix for a race condition on `b.block` (local copy before checking) and, following @ettersi's review, grew into a full hardening of the behavior block/restart protocol and the agent message delivery machinery. It also fixes #36.

The branch has been rebased onto current master.

## 1. Block/restart protocol (`container.jl`, `fsm.jl`, `coroutine_behavior.jl`)

The original commit closed the basic lost-wakeup race: `restart` now clears `b.block` and notifies *while holding the condition's lock*, and waiters re-check under the same lock before waiting. Review feedback and further analysis showed this was necessary but not sufficient:

- **All waiter sites** (OneShot/Cyclic/Waker/Ticker/Poisson, FSM, Coroutine — the latter two were flagged in review) now go through a shared `_wait_for_restart(b)`, which re-checks `b.block` **identity** (`b.block === oblock`) under the lock and loops until the behavior is truly unblocked or done. A plain null re-check was not enough: a `restart` + re-`block` sneaking in between capture and lock would leave the waiter waiting forever on a stale condition (or, for OneShot/Coroutine, let the action run while freshly blocked).
- **`restart(b)`** guards its null-out with the same identity check, so a stale restart cannot clobber a newer block condition (which would have made all future restarts early-return and stranded the real waiter).
- **Timer TOCTOU fixes**: `restart` and `block(b, millis)` capture the timer in a local, so a concurrent timer expiry can no longer cause `close(nothing)`/`wait(nothing)` `MethodError`s; the timer task's cleanup is guarded by `b.timer === t`, so a stale (orphaned) timer can no longer prematurely restart a newer block cycle.
- **`block(b)` is now idempotent** — a second `block` on an already-blocked behavior no longer silently replaces a condition that has a waiter on it.
- **`reset(b)`** (both the generic and the FSM method) now releases waiters with a locked notify instead of silently nulling `b.block`, which stranded them forever, and closes the timer via a local capture.

## 2. Agent message delivery (fixes #36)

`_listener_notify` and `_msgloop` `put!` into bounded listener channels while holding the `_processmsg` lock, while `receive`/`request`/`MessageBehavior` teardown takes the same lock in `_dont_listen` — deadlocking when a channel was full and its consumer had stopped taking. Fixed as sketched in the issue, plus a drain so no message is lost:

- New `_stop_listening(a, ch)` used by `receive`, `request` and `MessageBehavior`: **closes the channel before deregistering** (waking any blocked `put!` with an exception instead of deadlocking), then drains messages left behind in the channel back into the queue, so a message delivered between the last `take!` and teardown is redelivered rather than lost.
- `_listener_notify` skips already-ready channels and tolerates closed ones, so it can no longer block forever while holding the `_processmsg` lock.
- `_msgloop` keeps a message in the queue if its listener channel was closed mid-delivery, instead of dropping it and aborting the whole delivery sweep.

Two pre-existing bugs surfaced by the new tests, fixed in the same commit:

- `MessageBehavior(action, filt)` passed 8 args to a 9-field struct — a `MethodError` for any directly-constructed filtered `MessageBehavior`.
- `_msgloop` only swept the queue after a `notify`, so a message arriving before the loop's first `wait` (a startup window where notifications are lost) sat undelivered until the next unrelated message arrived. The loop now sweeps before waiting.

## 3. Tests

The suite barely covered containers/agents (3 CoroutineBehavior tests). New `test/container_tests.jl` (pure Julia, no Java master needed) covers container lifecycle and services, all behavior types, the block/restart protocol (including a concurrent block/restart stress from 4 threads), FSM transitions and reset, agent messaging, topics, request/reply, and regression tests for #36 (message flood with listener churn; `MessageBehavior` stopped mid-stream). `make test` now runs with `JULIA_NUM_THREADS=4` so the concurrent paths get real parallelism.

## 4. Docs

The module docstring's "not thread-safe" disclaimer applied only to the `Gateway`; it now says so explicitly — containers and agents are designed to be safe for multi-threaded use (which is what makes the fixes above matter).