### PR TITLE
Point docs to the new fjåge documentation site

### DIFF
--- a/docs/src/container.md
+++ b/docs/src/container.md
@@ -6,7 +6,7 @@ Slave containers are used to connect to Java master containers that host
 multi-language agent applications.
 
 The agents, behaviors and containers API is modeled on the Java version, and
-hence the [fjåge developer's guide](https://fjage.readthedocs.io/en/latest/)
+hence the [fjåge developer's guide](https://org-arl.github.io/fjage/)
 provides a good introduction to developing agents.
 
 ## Example

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,5 +31,6 @@ pkg> add Fjage
 ### Useful reading
 
 - [fjåge home](https://github.com/org-arl/fjage)
-- [fjåge developer's guide](https://fjage.readthedocs.io/en/latest/)
+- [fjåge developer's guide](https://org-arl.github.io/fjage/)
+- [Julia gateway chapter of the fjåge developer's guide](https://org-arl.github.io/fjage/juliagw.html)
 - [fjåge gateway API specifications](https://github.com/org-arl/fjage/blob/master/gateways/Gateways.md)


### PR DESCRIPTION
The fjåge developer's guide has moved from ReadTheDocs (toolchain defunct) to GitHub Pages: https://org-arl.github.io/fjage/ — see org-arl/fjage#423.

This updates the two `fjage.readthedocs.io` links in the Documenter pages accordingly, and adds a "Useful reading" entry for the guide's new [Julia gateway chapter](https://org-arl.github.io/fjage/juliagw.html), which in turn links back to this package's documentation — so the two sites now reference each other coherently.

Note: the new fjåge site (and the `juliagw.html` page) goes live once org-arl/fjage#423 merges and its docs workflow deploys; until then these links briefly point at the not-yet-deployed site, so it's best to merge this after that PR.