### PR TITLE
Update gateway to match revised specs + loosen string types

### DIFF
--- a/src/aid.jl
+++ b/src/aid.jl
@@ -14,8 +14,8 @@ end
 
 Create an AgentID, optionally with an owner.
 """
-AgentID(name::String, owner=nothing) = name[1] == '#' ? AgentID(name[2:end], true, owner) : AgentID(name, false, owner)
-AgentID(name::String, istopic::Bool) = AgentID(name, istopic, nothing)
+AgentID(name::AbstractString, owner=nothing) = name[1] == '#' ? AgentID(name[2:end], true, owner) : AgentID(name, false, owner)
+AgentID(name::AbstractString, istopic::Bool) = AgentID(name, istopic, nothing)
 
 """
     aid = topic([owner,] name[, subtopic])
@@ -23,12 +23,12 @@ AgentID(name::String, istopic::Bool) = AgentID(name, istopic, nothing)
 Creates an AgentID for a named topic, optionally owned by an owner. AgentIDs that are
 associated with gateways/agents can be used directly in `send()` and `request()` calls.
 """
-topic(name::String) = AgentID(name, true)
+topic(name::AbstractString) = AgentID(name, true)
 topic(aid::AgentID) = aid.istopic ? aid : AgentID(aid.name*"__ntf", true)
-topic(aid::AgentID, topic2::String) = AgentID(aid.name*"__"*topic2*"__ntf", true)
-topic(owner, name::String) = AgentID(name, true, owner)
+topic(aid::AgentID, topic2::AbstractString) = AgentID(aid.name*"__"*topic2*"__ntf", true)
+topic(owner, name::AbstractString) = AgentID(name, true, owner)
 topic(owner, aid::AgentID) = aid.istopic ? aid : AgentID(aid.name*"__ntf", true, owner)
-topic(owner, aid::AgentID, topic2::String) = AgentID(aid.name*"__"*topic2*"__ntf", true, owner)
+topic(owner, aid::AgentID, topic2::AbstractString) = AgentID(aid.name*"__"*topic2*"__ntf", true, owner)
 
 name(aid::AgentID) = aid.name
 owner(aid::AgentID) = aid.owner

--- a/src/container.jl
+++ b/src/container.jl
@@ -231,7 +231,7 @@ name(c::Container) = c.name[]
 
 Set name of the container.
 """
-name!(c::Container, s::String) = (c.name[] = s)
+name!(c::Container, s::AbstractString) = (c.name[] = s)
 
 function Base.show(io::IO, c::Container)
   print(io, typeof(c), "[name=\"", name(c), "\", running=", c.running[], ", agents=", length(c.agents), "]")
@@ -296,16 +296,16 @@ removelistener(::Container, listener) = false
 
 """
     containsagent(container::Container, aid::AgentID)
-    containsagent(container::Container, name::String)
+    containsagent(container::Container, name::AbstractString)
 
 Check if an agent is running in the container.
 """
 containsagent(c::Container, aid::AgentID) = name(aid) ∈ keys(c.agents)
-containsagent(c::Container, name::String) = name ∈ keys(c.agents)
+containsagent(c::Container, name::AbstractString) = name ∈ keys(c.agents)
 
 """
     canlocateagent(container::Container, aid::AgentID)
-    canlocateagent(container::Container, name::String)
+    canlocateagent(container::Container, name::AbstractString)
 
 Check if an agent is running in the container, or in any of the remote containers.
 """
@@ -322,11 +322,11 @@ end
 
 """
     agent(container::Container, aid::AgentID)
-    agent(container::Container, name::String)
+    agent(container::Container, name::AbstractString)
 
 Get the agent ID of an agent specified by name or its agent ID.
 """
-agent(c::Container, name::String) = name ∈ keys(c.agents) ? c.agents[name] : nothing
+agent(c::Container, name::AbstractString) = name ∈ keys(c.agents) ? c.agents[name] : nothing
 agent(c::Container, aid::AgentID) = agent(c, name(aid))
 
 """
@@ -350,7 +350,7 @@ services(c::Container) = collect(keys(c.services))
 Run an agent in a container. If the name is not specified, a unique name is randomly
 generated.
 """
-function add(c::Container, name::String, a::Agent)
+function add(c::Container, name::AbstractString, a::Agent)
   canlocateagent(c, name) && throw(ArgumentError("Duplicate agent name"))
   a._container = c
   a._aid = AgentID(name)
@@ -366,12 +366,12 @@ add(c::Container, a::Agent) = add(c, string(typeof(a)) * "-" * string(uuid4())[1
 
 """
     kill(container::Container, aid::AgentID)
-    kill(container::Container, name::String)
+    kill(container::Container, name::AbstractString)
     kill(container::Container, agent::Agent)
 
 Stop an agent running in a container.
 """
-function Base.kill(c::Container, aid::String)
+function Base.kill(c::Container, aid::AbstractString)
   containsagent(c, aid) || return false
   a = c.agents[aid]
   if c.running[]
@@ -546,11 +546,11 @@ function unsubscribe(c::SlaveContainer, t::AgentID, a::Agent)
 end
 
 """
-    register(c::Container, aid::AgentID, svc::String)
+    register(c::Container, aid::AgentID, svc::AbstractString)
 
 Register agent `aid` as providing service `svc`.
 """
-function register(c::Container, aid::AgentID, svc::String)
+function register(c::Container, aid::AgentID, svc::AbstractString)
   svc ∈ keys(c.services) || (c.services[svc] = Set{AgentID}())
   push!(c.services[svc], aid)
   true
@@ -567,45 +567,45 @@ function deregister(c::Container, aid::AgentID)
 end
 
 """
-    deregister(c::Container, aid::AgentID, svc::String)
+    deregister(c::Container, aid::AgentID, svc::AbstractString)
 
 Deregister agent `aid` from providing service `svc`.
 """
-function deregister(c::Container, aid::AgentID, svc::String)
+function deregister(c::Container, aid::AgentID, svc::AbstractString)
   svc ∈ keys(c.services) || return false
   delete!(c.services[svc], aid)
   true
 end
 
 """
-    agentforservice(c::Container, svc::String, owner::Agent)
+    agentforservice(c::Container, svc::AbstractString, owner::Agent)
 
 Lookup any agent providing the service `svc`, and return an `AgentID` owned
 by `owner`. Returns `nothing` if no agent providing specified service found.
 """
-function agentforservice(c::StandaloneContainer, svc::String, owner::Agent)
+function agentforservice(c::StandaloneContainer, svc::AbstractString, owner::Agent)
   svc ∈ keys(c.services) || return nothing
   AgentID(name(first(c.services[svc])), false, owner)
 end
 
 """
-    agentsforservice(c::Container, svc::String, owner::Agent)
+    agentsforservice(c::Container, svc::AbstractString, owner::Agent)
 
 Lookup all agents providing the service `svc`, and return list of `AgentID` owned
 by `owner`. Returns an empty list if no agent providing specified service found.
 """
-function agentsforservice(c::StandaloneContainer, svc::String, owner::Agent)
+function agentsforservice(c::StandaloneContainer, svc::AbstractString, owner::Agent)
   svc ∈ keys(c.services) || return AgentID[]
   [AgentID(name(s), false, owner) for s ∈ c.services[svc]]
 end
 
-function agentforservice(c::SlaveContainer, svc::String, owner::Agent)
+function agentforservice(c::SlaveContainer, svc::AbstractString, owner::Agent)
   rq = Dict("action" => "agentForService", "service" => svc)
   rsp = _ask(c, rq)
   haskey(rsp, "agentID") ? AgentID(rsp["agentID"], false, owner) : nothing
 end
 
-function agentsforservice(c::SlaveContainer, svc::String, owner::Agent)
+function agentsforservice(c::SlaveContainer, svc::AbstractString, owner::Agent)
   rq = Dict("action" => "agentsForService", "service" => svc)
   rsp = _ask(c, rq)
   [AgentID(a, false, owner) for a in rsp["agentIDs"]]
@@ -672,7 +672,7 @@ function _subscriptions(c::SlaveContainer)
   collect(string.(ks))
 end
 
-function _agentsforservice(c::Container, svc::String)
+function _agentsforservice(c::Container, svc::AbstractString)
   svc ∈ keys(c.services) || return AgentID[]
   collect(c.services[svc])
 end
@@ -1024,11 +1024,11 @@ Get the name of the agent.
 name(a::Agent) = name(a._aid)
 
 """
-    agent(a::Agent, name::String)
+    agent(a::Agent, name::AbstractString)
 
 Generate an owned `AgentID` for an agent with the given name.
 """
-agent(a::Agent, name::String) = AgentID(name, false, a)
+agent(a::Agent, name::AbstractString) = AgentID(name, false, a)
 
 """
     currenttimemillis(a::Agent)
@@ -1077,35 +1077,35 @@ Unsubscribe agent from specified topic.
 unsubscribe(a::Agent, t::AgentID) = unsubscribe(container(a), t, a)
 
 """
-    register(a::Agent, svc::String)
+    register(a::Agent, svc::AbstractString)
 
 Register agent as providing a specied service.
 """
-register(a::Agent, svc::String) = register(container(a), AgentID(a), svc)
+register(a::Agent, svc::AbstractString) = register(container(a), AgentID(a), svc)
 
 """
-    deregister(a::Agent, svc::String)
+    deregister(a::Agent, svc::AbstractString)
 
 Deregister agent from providing a specied service.
 """
-deregister(a::Agent, svc::String) = deregister(container(a), AgentID(a), svc)
+deregister(a::Agent, svc::AbstractString) = deregister(container(a), AgentID(a), svc)
 
 """
-    agentforservice(a::Agent, svc::String)
+    agentforservice(a::Agent, svc::AbstractString)
 
 Find an agent providing a specified service. Returns an owned `AgentID` for the
 service provider, if one is found, `nothing` otherwise.
 """
-agentforservice(a::Agent, svc::String) = agentforservice(container(a), svc, a)
+agentforservice(a::Agent, svc::AbstractString) = agentforservice(container(a), svc, a)
 
 """
-    agentsforservice(a::Agent, svc::String)
+    agentsforservice(a::Agent, svc::AbstractString)
 
 Get a list of agents providing a specified service. Returns a list of owned
 `AgentID` for the service providers. The list may be empty if no service providers
 are found.
 """
-agentsforservice(a::Agent, svc::String) = agentsforservice(container(a), svc, a)
+agentsforservice(a::Agent, svc::AbstractString) = agentsforservice(container(a), svc, a)
 
 """
     store(a::Agent)

--- a/src/gw.jl
+++ b/src/gw.jl
@@ -19,7 +19,7 @@ struct Gateway
   host::String
   port::Int
   reconnect::Ref{Bool}
-  function Gateway(name::String, host, port::Int; reconnect=true)
+  function Gateway(name::AbstractString, host, port::Int; reconnect=true)
     startswith(name, "gateway-") || (name = "gateway-" * name)  # spec: gateway agent names are prefixed "gateway-"
     gw = new(
       AgentID(name, false),
@@ -212,7 +212,7 @@ function _run(gw)
 end
 
 AgentID(gw::Gateway) = gw.agentID
-agent(gw::Gateway, name::String) = AgentID(name, false, gw)
+agent(gw::Gateway, name::AbstractString) = AgentID(name, false, gw)
 
 "Find an agent that provides a named service."
 function agentforservice(gw::Gateway, svc::AbstractString, timeout=6000)

--- a/src/gw.jl
+++ b/src/gw.jl
@@ -20,6 +20,7 @@ struct Gateway
   port::Int
   reconnect::Ref{Bool}
   function Gateway(name::String, host, port::Int; reconnect=true)
+    startswith(name, "gateway-") || (name = "gateway-" * name)  # spec: gateway agent names are prefixed "gateway-"
     gw = new(
       AgentID(name, false),
       Ref(connect(host, port)),
@@ -64,6 +65,7 @@ function _respond(gw, rq, rsp)
 end
 
 # ask master container a question, and wait for reply
+# 2-arg: blocks indefinitely; used by SlaveContainer (container.jl). Left untouched.
 function _ask(gw, rq)
   id = string(uuid4())
   s = JSON.json(merge!(JsonObject("id" => id), rq))
@@ -72,6 +74,28 @@ function _ask(gw, rq)
   try
     _println(gw.sock[], s)
     return take!(ch)
+  finally
+    delete!(gw.pending, id)
+  end
+end
+
+# 3-arg: bounded/timeout variant; used only by the Gateway discovery methods below.
+# timeout (ms): < 0 blocks forever, 0 is non-blocking, otherwise waits up to timeout
+# and returns an empty JsonObject() on timeout (interpreted as "not found").
+function _ask(gw, rq, timeout)
+  timeout < 0 && return _ask(gw, rq)   # block forever (delegates to the 2-arg method)
+  id = string(uuid4())
+  s = JSON.json(merge!(JsonObject("id" => id), rq))
+  ch = Channel{JsonObject}(1)
+  gw.pending[id] = ch
+  try
+    _println(gw.sock[], s)
+    timeout == 0 && return isready(ch) ? take!(ch) : JsonObject()
+    # _run() is the sole producer into ch and this is the sole consumer, so there is
+    # no producer race: we only ever read (isready) or take!, never put!/close ch. If
+    # the reply lands after we give up, it harmlessly fills the (then-abandoned)
+    # channel, and the finally-delete! makes _run() ignore any later reply for this id.
+    timedwait(() -> isready(ch), timeout / 1e3; pollint=0.001) === :ok ? take!(ch) : JsonObject()
   finally
     delete!(gw.pending, id)
   end
@@ -191,17 +215,39 @@ AgentID(gw::Gateway) = gw.agentID
 agent(gw::Gateway, name::String) = AgentID(name, false, gw)
 
 "Find an agent that provides a named service."
-function agentforservice(gw::Gateway, svc::String)
+function agentforservice(gw::Gateway, svc::AbstractString, timeout=6000)
   rq = JsonObject("action" => "agentForService", "service" => svc)
-  rsp = _ask(gw, rq)
+  rsp = _ask(gw, rq, timeout)
   haskey(rsp, "agentID") ? AgentID(rsp["agentID"], false, gw) : nothing
 end
 
-"Find all agents that provides a named service."
-function agentsforservice(gw::Gateway, svc::String)
+"Find all agents that provide a named service."
+function agentsforservice(gw::Gateway, svc::AbstractString, timeout=6000)
   rq = JsonObject("action" => "agentsForService", "service" => svc)
-  rsp = _ask(gw, rq)
-  [AgentID(a, false, gw) for a ∈ rsp["agentIDs"]]
+  rsp = _ask(gw, rq, timeout)
+  haskey(rsp, "agentIDs") ? [AgentID(a, false, gw) for a ∈ rsp["agentIDs"]] : AgentID[]
+end
+
+"Find all agents running on the master container."
+function agents(gw::Gateway, timeout=6000)
+  rq = JsonObject("action" => "agents")
+  rsp = _ask(gw, rq, timeout)
+  haskey(rsp, "agentIDs") ? [AgentID(a, false, gw) for a ∈ rsp["agentIDs"]] : AgentID[]
+end
+
+"Check if an agent is running on the master container."
+containsagent(gw::Gateway, aid::AgentID, timeout=6000) = containsagent(gw, aid.name, timeout)
+function containsagent(gw::Gateway, aid::AbstractString, timeout=6000)
+  rq = JsonObject("action" => "containsAgent", "agentID" => aid)
+  rsp = _ask(gw, rq, timeout)
+  haskey(rsp, "answer") ? rsp["answer"]::Bool : false
+end
+
+"Find all services available on the master container."
+function services(gw::Gateway, timeout=6000)
+  rq = JsonObject("action" => "services")
+  rsp = _ask(gw, rq, timeout)
+  haskey(rsp, "services") ? Vector{String}(rsp["services"]) : String[]
 end
 
 "Subscribe to receive all messages sent to the given topic."

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -135,7 +135,7 @@ function registermessages(msg=subtypes(Message))
   end
 end
 
-function _messageclass_lookup(classname::String)
+function _messageclass_lookup(classname::AbstractString)
   haskey(_messageclasses, classname) && return _messageclasses[classname]
   GenericMessage{Symbol(classname)}
 end
@@ -263,7 +263,7 @@ Fjage.classname(::Type{GenericMessage{T}}) where T = string(T)
 Fjage.classname(::GenericMessage{T}) where T = string(T)
 
 GenericMessage(args...) = GenericMessage{Symbol("org.arl.fjage.GenericMessage")}(args...)
-GenericMessage(clazz::String, perf::Symbol=Performative.INFORM; kwargs...) = GenericMessage{Symbol(clazz)}(; performative=perf, kwargs...)
+GenericMessage(clazz::AbstractString, perf::Symbol=Performative.INFORM; kwargs...) = GenericMessage{Symbol(clazz)}(; performative=perf, kwargs...)
 
 # adds notation message.field
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,39 @@ try
       @test length(alist) == 0
     end
 
+    @testset "agentforservice (timeout arg)" begin
+      s2 = agentforservice(gw, "org.arl.fjage.shell.Services.SHELL", 3000)
+      @test typeof(s2) <: AgentID
+      @test s2.name == "shell"
+      # short timeout to a bogus service returns nothing without hanging
+      @test agentforservice(gw, "org.arl.dummy.Services.DUMMY", 500) === nothing
+    end
+
+    @testset "agents" begin
+      alist = agents(gw)
+      @test typeof(alist) <: Array
+      @test !isempty(alist)
+      @test any(a -> a.name == "shell", alist)
+    end
+
+    @testset "containsagent" begin
+      @test containsagent(gw, "shell") == true
+      @test containsagent(gw, AgentID("shell")) == true
+      @test containsagent(gw, "org.arl.dummy.NoSuchAgent") == false
+    end
+
+    @testset "services" begin
+      svcs = services(gw)
+      @test typeof(svcs) <: Array
+      @test !isempty(svcs)
+    end
+
+    @testset "gateway- name prefix" begin
+      gw2 = Gateway("myclient", "localhost", 5081)
+      @test name(gw2) == "gateway-myclient"
+      close(gw2)
+    end
+
     abstract type MyAbstractReq <: Message end
     @message "org.arl.fjage.test.MyAbstractReq" struct MyAbstractReq <: MyAbstractReq end
     @message "org.arl.fjage.test.MyReq" Performative.AGREE struct MyReq <: MyAbstractReq end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,18 @@ try
       close(gw2)
     end
 
+    @testset "AbstractString names accepted" begin
+      # SubString (e.g. from strip/split) must be accepted, not only String
+      svc = strip("  org.arl.fjage.shell.Services.SHELL  ")
+      @test svc isa SubString{String}
+      @test agentforservice(gw, svc).name == "shell"
+      @test length(agentsforservice(gw, svc)) == 1
+      nm = split("shell,ignored", ",")[1]
+      @test nm isa SubString{String}
+      @test containsagent(gw, nm) == true
+      @test agent(gw, nm).name == "shell"
+    end
+
     abstract type MyAbstractReq <: Message end
     @message "org.arl.fjage.test.MyAbstractReq" struct MyAbstractReq <: MyAbstractReq end
     @message "org.arl.fjage.test.MyReq" Performative.AGREE struct MyReq <: MyAbstractReq end


### PR DESCRIPTION
Two related changes to the Gateway API (one commit each).

## 1. `feat(gateway)`: discovery-method timeouts + `agents`/`services`/`containsagent`

Brings the `Gateway` class in line with the [fjåge Gateway API spec](https://github.com/org-arl/fjage/blob/master/gateways/Gateways.md)'s discovery methods (recently updated, commit `c723f9e9`, to standardize **6000 ms** default timeouts and add `agents()`/`containsAgent()`/`services()`), and fixes a latent hang: today `agentforservice`/`agentsforservice` block **forever** if the master never replies, which can hang a `UnetSocket` during setup/provider resolution.

- **Timeout-aware `_ask`.** Added a 3-arg `_ask(gw, rq, timeout)` variant (ms: `<0` blocks forever, `0` non-blocking, else bounded → empty `JsonObject()` on timeout). The existing **2-arg `_ask` is left untouched**, so `SlaveContainer` keeps its exact block-forever behavior. The bounded variant is a pure *consumer* of the pending channel (waits via `timedwait`, only ever reads/`take!`s, never `put!`/`close`), so `_run()` stays the sole producer — **no producer race under multithreading**; a late reply just harmlessly fills the abandoned channel and the `finally`-`delete!` makes `_run()` ignore it.
- **`agentforservice` / `agentsforservice`** gain an optional `timeout` (default 6000 ms) and no longer block forever. `agentsforservice` also no longer `KeyError`s on an empty response (returns `AgentID[]`).
- **New `agents`, `containsagent`, `services`** for `Gateway`, mirroring the JSON shapes already used by `SlaveContainer`.
- **`gateway-` name prefix.** A caller-supplied name lacking the prefix now gets it prepended, per the spec.

`timeout` args are left untyped (matching `request`/`receive`); the value only needs `Real` arithmetic.

## 2. `refactor(api)`: accept `AbstractString` for name/service/topic/class arguments

The agent-name, service-name, topic-name and message-class-name arguments across the `Gateway`, `AgentID`, `Container` and `Message` APIs were typed `::String`, which rejects `SubString` (from `strip`/`split`/slicing) — a common Julia footgun (`agentforservice(gw, strip(x))` would `MethodError`). Widened those argument annotations to `::AbstractString` for consistency. Struct fields (`AgentID.name`, `host`, message fields) keep concrete `String` storage; conversion happens automatically at the `AgentID` default constructor, `Symbol()`, and `Dict`-key boundaries, so `String` callers are unaffected.

Explicitly **not** changed: the constructor still throws on first-connect failure (a Julia constructor returning `nothing` would be wrong — a companion spec PR, org-arl/fjage#430, relaxes that wording instead); `sentAt` left as-is; struct field storage types unchanged.

## Testing

- Full suite against a live fjåge 1.15.1 master: **`Fjage | 82 82`** passing (incl. new tests for the discovery methods, `timeout` argument, name prefix, and `SubString` name acceptance), plus container/coroutine/clone testsets green — **0 failures**.
- Also verified against a live UnetStack master under `JULIA_NUM_THREADS=4`: discovery methods correct; `agentforservice(bogus)` → `nothing` without hanging; bounded `_ask` times out precisely (301 ms for a 300 ms budget) with `gw.pending` empty afterward (no leak) across 500+ calls; ~2.8 ms happy-path latency.